### PR TITLE
Response fix

### DIFF
--- a/types/credentials.go
+++ b/types/credentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openfaas/faas-provider/auth"
 )
 
+// GetCredentials retrieves basic auth credentials
 func GetCredentials() *auth.BasicAuthCredentials {
 	var credentials *auth.BasicAuthCredentials
 

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -24,7 +24,7 @@ type FunctionLookupBuilder struct {
 	TopicDelimiter string
 }
 
-//getNamespaces get openfaas namespaces
+// getNamespaces gets OpenFaaS namespaces
 func (s *FunctionLookupBuilder) getNamespaces() ([]string, error) {
 	var (
 		err        error
@@ -45,7 +45,9 @@ func (s *FunctionLookupBuilder) getNamespaces() ([]string, error) {
 	}
 
 	if res.Body != nil {
-		defer res.Body.Close()
+		defer func() {
+			_ = res.Body.Close()
+		}()
 	}
 
 	if res.StatusCode != http.StatusNotFound {
@@ -91,12 +93,14 @@ func (s *FunctionLookupBuilder) getFunctions(namespace string) ([]types.Function
 	}
 
 	if res.Body != nil {
-		defer res.Body.Close()
+		defer func() {
+			_ = res.Body.Close()
+		}()
 	}
 
 	bytesOut, _ := ioutil.ReadAll(res.Body)
 
-	functions := []types.FunctionStatus{}
+	var functions []types.FunctionStatus
 	marshalErr := json.Unmarshal(bytesOut, &functions)
 
 	if marshalErr != nil {

--- a/types/function_list_builder_test.go
+++ b/types/function_list_builder_test.go
@@ -18,9 +18,9 @@ func TestBuildSingleMatchingFunction(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = "topic1"
 
@@ -30,7 +30,7 @@ func TestBuildSingleMatchingFunction(t *testing.T) {
 				Namespace:   "openfaas-fn",
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -56,9 +56,9 @@ func Test_Build_SingleFunctionNoDelimiter(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = "topic1"
 
@@ -67,7 +67,7 @@ func Test_Build_SingleFunctionNoDelimiter(t *testing.T) {
 				Annotations: &annotationMap,
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -92,9 +92,9 @@ func TestBuildMultiMatchingFunction(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = "topic1,topic2,topic3"
 
@@ -103,7 +103,7 @@ func TestBuildMultiMatchingFunction(t *testing.T) {
 				Annotations: &annotationMap,
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -126,9 +126,9 @@ func TestBuildMultiMatchingFunction(t *testing.T) {
 func TestBuildNoFunctions(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		functions := []types.FunctionStatus{}
+		var functions []types.FunctionStatus
 		bytesOut, _ := json.Marshal(functions)
-		w.Write(bytesOut)
+		_, _ = w.Write(bytesOut)
 	}))
 
 	client := srv.Client()
@@ -153,10 +153,10 @@ func Test_Build_JustDelim(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
 
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = ","
 
@@ -165,7 +165,7 @@ func Test_Build_JustDelim(t *testing.T) {
 				Annotations: &annotationMap,
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -191,9 +191,9 @@ func Test_Build_MultiMatchingFunctionBespokeDelim(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = "topic1|topic2|topic3,withcomma"
 
@@ -202,7 +202,7 @@ func Test_Build_MultiMatchingFunctionBespokeDelim(t *testing.T) {
 				Annotations: &annotationMap,
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -331,9 +331,9 @@ func Test_BuildMultipleNamespaceFunction(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn", "fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			annotationMap := make(map[string]string)
 			annotationMap["topic"] = "topic1"
 
@@ -343,7 +343,7 @@ func Test_BuildMultipleNamespaceFunction(t *testing.T) {
 				Namespace:   "openfaas-fn",
 			})
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -374,7 +374,7 @@ func Test_GetNamespaces(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		namespaces := []string{"openfaas-fn", "fn"}
 		bytesOut, _ := json.Marshal(namespaces)
-		w.Write(bytesOut)
+		_, _ = w.Write(bytesOut)
 	}))
 
 	client := srv.Client()
@@ -395,7 +395,7 @@ func Test_GetNamespaces(t *testing.T) {
 func Test_GetNamespaces_ProviderGives404(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("Not available"))
+		_, _ = w.Write([]byte("Not available"))
 	}))
 
 	client := srv.Client()
@@ -421,9 +421,9 @@ func Test_GetFunctions(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			if r.URL.Query().Get("namespace") == "openfaas-fn" {
 				annotationMap := make(map[string]string)
 				annotationMap["topic"] = "topic1"
@@ -435,7 +435,7 @@ func Test_GetFunctions(t *testing.T) {
 				})
 			}
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 
@@ -461,9 +461,9 @@ func Test_GetEmptyFunctions(t *testing.T) {
 		if r.URL.Path == "/system/namespaces" {
 			namespaces := []string{"openfaas-fn"}
 			bytesOut, _ := json.Marshal(namespaces)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		} else {
-			functions := []types.FunctionStatus{}
+			var functions []types.FunctionStatus
 			if r.URL.Query().Get("namespace") == "openfaas-fn" {
 				annotationMap := make(map[string]string)
 				annotationMap["topic"] = "topic1"
@@ -476,7 +476,7 @@ func Test_GetEmptyFunctions(t *testing.T) {
 
 			}
 			bytesOut, _ := json.Marshal(functions)
-			w.Write(bytesOut)
+			_, _ = w.Write(bytesOut)
 		}
 	}))
 

--- a/types/response_printer.go
+++ b/types/response_printer.go
@@ -19,9 +19,9 @@ func (rp *ResponsePrinter) Response(res InvokerResponse) {
 	if res.Error != nil {
 		log.Printf("connector-sdk got error: %s", res.Error.Error())
 	} else {
-		log.Printf("connector-sdk got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(*res.Body))
+		log.Printf("connector-sdk got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(res.Body))
 		if rp.PrintResponseBody {
-			fmt.Printf("[%d] %s => %s\n%s\n", res.Status, res.Topic, res.Function, string(*res.Body))
+			fmt.Printf("[%d] %s => %s\n%s\n", res.Status, res.Topic, res.Function, string(res.Body))
 		}
 	}
 }


### PR DESCRIPTION
- Remove unnecessary pointer types
- Expose InvokeFunction to selectively invoke a function, e.g. for retries
- Allow to pass a logger, remove hardcoded logger
- Invoker returns number of functions matched and errors
- Invoker will also send detailed response in case of error
- Parallelize invoking functions
- Standardize function signatures, e.g. use []bytes consistently
- Fix linter issues (comments and slice initialization)
